### PR TITLE
Don't retain heads in side-effectful iterations

### DIFF
--- a/src/mount/core.clj
+++ b/src/mount/core.clj
@@ -119,7 +119,8 @@
   (let [done (atom [])]
     (->> states
          (sort-by (comp :order meta) order)
-         (run! #(fun % (meta %) done)))
+         (map #(fun % (meta %) done))
+         dorun)
     @done))
 
 (defn- merge-lifecycles
@@ -159,17 +160,17 @@
 
 (defn stop [& states]
   (let [states (or states (find-all-states))
-        _ (run! unsub states)     ;; unmark substitutions marked by "start-with"
+        _ (dorun (map unsub states))     ;; unmark substitutions marked by "start-with"
         stopped (bring states down >)]
-    (run! rollback! states)       ;; restore to origin from "start-with"
+    (dorun (map rollback! states))       ;; restore to origin from "start-with"
     {:stopped stopped}))
 
 (defn stop-except [& states]
   (let [all (set (find-all-states))
         states (remove (set states) all)
-        _ (run! unsub states)     ;; unmark substitutions marked by "start-with"
+        _ (dorun (map unsub states))     ;; unmark substitutions marked by "start-with"
         stopped (bring states down >)]
-    (run! rollback! states)       ;; restore to origin from "start-with"
+    (dorun (map rollback! states))       ;; restore to origin from "start-with"
     {:stopped stopped}))
 
 (defn start-with-args [xs & states]

--- a/src/mount/core.clj
+++ b/src/mount/core.clj
@@ -119,8 +119,7 @@
   (let [done (atom [])]
     (->> states
          (sort-by (comp :order meta) order)
-         (map #(fun % (meta %) done))
-         doall)
+         (run! #(fun % (meta %) done)))
     @done))
 
 (defn- merge-lifecycles
@@ -160,17 +159,17 @@
 
 (defn stop [& states]
   (let [states (or states (find-all-states))
-        _ (doall (map unsub states))     ;; unmark substitutions marked by "start-with"
+        _ (run! unsub states)     ;; unmark substitutions marked by "start-with"
         stopped (bring states down >)]
-    (doall (map rollback! states))       ;; restore to origin from "start-with"
+    (run! rollback! states)       ;; restore to origin from "start-with"
     {:stopped stopped}))
 
 (defn stop-except [& states]
   (let [all (set (find-all-states))
         states (remove (set states) all)
-        _ (doall (map unsub states))     ;; unmark substitutions marked by "start-with"
+        _ (run! unsub states)     ;; unmark substitutions marked by "start-with"
         stopped (bring states down >)]
-    (doall (map rollback! states))       ;; restore to origin from "start-with"
+    (run! rollback! states)       ;; restore to origin from "start-with"
     {:stopped stopped}))
 
 (defn start-with-args [xs & states]
@@ -180,9 +179,8 @@
     (start)))
 
 (defn start-with [with]
-  (doall
-    (for [[from to] with]
-      (substitute! from to)))
+  (doseq [[from to] with]
+    (substitute! from to))
   (start))
 
 (defn start-without [& states]


### PR DESCRIPTION
Replace forms iterating over collections for the purpose of side-effects
with alternatives which don't retain heads of collections.
