### PR TITLE
Quote *ns* var in defstate macro to avoid aot compilation issues.

### DIFF
--- a/src/mount/core.cljc
+++ b/src/mount/core.cljc
@@ -136,7 +136,7 @@
     (defmacro defstate [state & body]
       (let [[state params] (macro/name-with-attributes state body)
             {:keys [start stop] :as lifecycle} (apply hash-map params)
-            state-name (with-ns *ns* state)
+            state-name `(with-ns ~*ns* state)
             order (make-state-seq state-name)]
         (validate lifecycle)
         (let [s-meta (cond-> {:order order
@@ -151,7 +151,7 @@
 
 #?(:clj
     (defmacro defstate! [state & {:keys [start! stop!]}]
-      (let [state-name (with-ns *ns* state)]
+      (let [state-name `(with-ns ~*ns* state)]
         `(defstate ~state
            :start (~'let [~state (mount/current-state ~state-name)]
                     ~start!)


### PR DESCRIPTION
Fixes #73 