### PR TITLE
Add docstring for defstate

### DIFF
--- a/src/mount/core.cljc
+++ b/src/mount/core.cljc
@@ -160,7 +160,11 @@
       (up s-name with-inst (atom #{})))))
 
 #?(:clj
-    (defmacro defstate [state & body]
+    (defmacro defstate 
+      "Defines a state. Restarts on recompilation. 
+       Pass ^{:on-reload :noop} to prevent auto-restart
+       on ns recompilation, or :stop to stop on recompilation."
+      [state & body]
       (let [[state params] (macro/name-with-attributes state body)
             {:keys [start stop] :as lifecycle} (apply hash-map params)
             state-name (with-ns *ns* state)


### PR DESCRIPTION
I keep forgetting the syntax for this. Rather than having to go diving for the README all the time, would be good to have this vital information. in the docstring.