### PR TITLE
Remove ref to old state alias in `swap-states`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Here is a more "involved" example:
     mount/start)
 ```
 
-This will do the same thing as the previous example plus it would swap `#'foo/a` with `#'test/a` state and `#'baz/e` with `{:datomic {:uri "datomic:mem://composable-mount"}}` value before starting the application.
+This will do the same thing as the previous example plus it would swap `#'foo/a` with alternative `:start` and `:stop` functions and `#'baz/e` with `{:datomic {:uri "datomic:mem://composable-mount"}}` value before starting the application.
 
 ## Start and Stop Parts of Application
 


### PR DESCRIPTION
Looks like this was overlooked in e2ef7bba558cc2dd831b311d0c11b728220b1c7f... feel free to change the wording :)