### PR TITLE
[CONTINUED] Self-host ClojureScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mount",
+  "version": "0.1.12",
+  "license": "EPL-1.0",
+  "homepage": "https://github.com/tolitius/mount",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tolitius/mount"
+  },
+  "author": {
+    "name" : "tolitius",
+    "url" : "http://www.dotkam.com"
+  }
+  ,
+  "files": [
+    "src/*"
+  ],
+  "directories": {
+    "lib": "src"
+  }
+}

--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,8 @@
          :source-paths ["test/core"]}
 
   :profiles {:dev {:source-paths ["dev" "dev/clj" "test/clj"]
-                   :dependencies [[org.clojure/clojure "1.7.0"]
-                                  [org.clojure/clojurescript "1.7.170"]; :classifier "aot"]
+                   :dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/clojurescript "1.9.946"]; :classifier "aot"]
                                   [datascript "0.13.3"]
                                   [compojure "1.4.0"]
                                   [ring/ring-jetty-adapter "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,9 @@
 
   :dependencies [] ;; for visual clarity
 
+  :tach {:test-runner-ns 'mount.test-self-host
+         :source-paths ["test/core"]}
+
   :profiles {:dev {:source-paths ["dev" "dev/clj" "test/clj"]
                    :dependencies [[org.clojure/clojure "1.7.0"]
                                   [org.clojure/clojurescript "1.7.170"]; :classifier "aot"]
@@ -27,7 +30,8 @@
                    :plugins [[lein-cljsbuild "1.1.1"]
                              [lein-doo "0.1.6"]
                              [lein-figwheel "0.5.0-2"]
-                             [test2junit "1.1.3"]]
+                             [test2junit "1.1.3"]
+                             [lein-tach "1.0.0"]]
 
                    :test2junit-output-dir ~(or (System/getenv "CIRCLE_TEST_REPORTS") "target/test2junit")
 

--- a/src/mount/tools/macro.cljc
+++ b/src/mount/tools/macro.cljc
@@ -1,31 +1,56 @@
 (ns mount.tools.macro
-  #?(:cljs (:require-macros [mount.tools.macro])))
+  (:refer-clojure :exclude [case])
+  #?(:cljs (:require-macros [mount.tools.macro :refer [deftime case]])))
 
-#?(:clj
-    (defmacro if-clj [then else]
-      (if (-> &env :ns not)
-        then
-        else)))
+;; From https://github.com/cgrand/macrovich 0.2.0
+;; Licensed under EPL v1. Copyright Cristophe Grand.
+(defmacro deftime
+  "This block will only be evaluated at the correct time for macro definition, at other times its content
+   are removed.
+   For Clojure it always behaves like a `do` block.
+   For Clojurescript/JVM the block is only visible to Clojure.
+   For self-hosted Clojurescript the block is only visible when defining macros in the pseudo-namespace."
+  [& body]
+  (when #?(:clj (not (:ns &env)) :cljs (re-matches #".*\$macros" (name (ns-name *ns*))))
+    `(do ~@body)))
 
-#?(:clj
-    (defmacro on-error [msg f & {:keys [fail?]
-                                 :or {fail? true}}]
-      `(if-clj
-         (try ~f
-              (catch Throwable t#
-                (if ~fail?
-                  (throw (RuntimeException. ~msg t#))
-                  {:f-failed (ex-info ~msg {} t#)})))
-         (try ~f
-              (catch :default t#
-                (if ~fail?
-                  (throw (~'str ~msg " " t#))
-                  {:f-failed (ex-info ~msg {} t#)}))))))
+(defmacro usetime
+  "This block content is not included at macro definition time.
+   For Clojure it always behaves like a `do` block.
+   For Clojurescript/JVM the block is only visible to Clojurescript.
+   For self-hosted Clojurescript the block is invisible when defining macros in the pseudo-namespace."
+  [& body]
+  (when #?(:clj true :cljs (not (re-matches #".*\$macros" (name (ns-name *ns*)))))
+    `(do ~@body)))
 
-#?(:clj
-    (defmacro throw-runtime [msg]
-      `(throw (if-clj (RuntimeException. ~msg)
-                      (~'str ~msg)))))
+(defmacro case [& {:keys [cljs clj]}]
+  (if (contains? &env '&env)
+    `(if (:ns ~'&env) ~cljs ~clj)
+    (if #?(:clj (:ns &env) :cljs true)
+      cljs
+      clj)))
+
+(deftime
+
+(defmacro on-error [msg f & {:keys [fail?]
+                             :or {fail? true}}]
+  `(case
+     :clj  (try ~f
+             (catch Throwable t#
+               (if ~fail?
+                 (throw (RuntimeException. ~msg t#))
+                 {:f-failed (ex-info ~msg {} t#)})))
+     :cljs (try ~f
+             (catch :default t#
+               (if ~fail?
+                 (throw (~'str ~msg " " t#))
+                 {:f-failed (ex-info ~msg {} t#)})))))
+
+(defmacro throw-runtime [msg]
+  `(throw (case :clj  (RuntimeException. ~msg)
+                :cljs (~'str ~msg))))
+
+)
 
 ;; this is a one to one copy from https://github.com/clojure/tools.macro
 ;; to avoid a lib dependency for a single function

--- a/src/mount/tools/macro.cljc
+++ b/src/mount/tools/macro.cljc
@@ -1,54 +1,26 @@
 (ns mount.tools.macro
   (:refer-clojure :exclude [case])
-  #?(:cljs (:require-macros [mount.tools.macro :refer [deftime case]])))
-
-;; From https://github.com/cgrand/macrovich 0.2.0
-;; Licensed under EPL v1. Copyright Cristophe Grand.
-(defmacro deftime
-  "This block will only be evaluated at the correct time for macro definition, at other times its content
-   are removed.
-   For Clojure it always behaves like a `do` block.
-   For Clojurescript/JVM the block is only visible to Clojure.
-   For self-hosted Clojurescript the block is only visible when defining macros in the pseudo-namespace."
-  [& body]
-  (when #?(:clj (not (:ns &env)) :cljs (re-matches #".*\$macros" (name (ns-name *ns*))))
-    `(do ~@body)))
-
-(defmacro usetime
-  "This block content is not included at macro definition time.
-   For Clojure it always behaves like a `do` block.
-   For Clojurescript/JVM the block is only visible to Clojurescript.
-   For self-hosted Clojurescript the block is invisible when defining macros in the pseudo-namespace."
-  [& body]
-  (when #?(:clj true :cljs (not (re-matches #".*\$macros" (name (ns-name *ns*)))))
-    `(do ~@body)))
-
-(defmacro case [& {:keys [cljs clj]}]
-  (if (contains? &env '&env)
-    `(if (:ns ~'&env) ~cljs ~clj)
-    (if #?(:clj (:ns &env) :cljs true)
-      cljs
-      clj)))
+  #?(:cljs (:require-macros [mount.tools.macrovich :refer [deftime]])
+     :clj (:require [mount.tools.macrovich :refer [deftime]])))
 
 (deftime
 
-(defmacro on-error [msg f & {:keys [fail?]
-                             :or {fail? true}}]
-  `(case
-     :clj  (try ~f
-             (catch Throwable t#
-               (if ~fail?
-                 (throw (RuntimeException. ~msg t#))
-                 {:f-failed (ex-info ~msg {} t#)})))
-     :cljs (try ~f
-             (catch :default t#
-               (if ~fail?
-                 (throw (~'str ~msg " " t#))
-                 {:f-failed (ex-info ~msg {} t#)})))))
+  (defmacro on-error [msg f & {:keys [fail?]
+                               :or {fail? true}}]
+    `(mount.tools.macrovich/case
+      :clj  (try ~f
+                 (catch Throwable t#
+                   (if ~fail?
+                     (throw (RuntimeException. ~msg t#))
+                     {:f-failed (ex-info ~msg {} t#)})))
+      :cljs (try ~f
+                 (catch :default t#
+                   (if ~fail?
+                     (throw (~'str ~msg " " t#))
+                     {:f-failed (ex-info ~msg {} t#)})))))
 
-(defmacro throw-runtime [msg]
-  `(throw (case :clj  (RuntimeException. ~msg)
-                :cljs (~'str ~msg))))
+  (defmacro throw-runtime [msg]
+    `(throw (mount.tools.macrovich/case :clj (RuntimeException. ~msg) :cljs (~'str ~msg))))
 
 )
 

--- a/src/mount/tools/macrovich.cljc
+++ b/src/mount/tools/macrovich.cljc
@@ -1,0 +1,21 @@
+(ns ^{:doc "From https://github.com/cgrand/macrovich. Licensed under EPL v1.
+            Copyright Cristophe Grand." }
+    mount.tools.macrovich
+  (:refer-clojure :exclude [case]))
+
+(defmacro deftime
+  "This block will only be evaluated at the correct time for macro definition, at other times its content
+   are removed.
+   For Clojure it always behaves like a `do` block.
+   For Clojurescript/JVM the block is only visible to Clojure.
+   For self-hosted Clojurescript the block is only visible when defining macros in the pseudo-namespace."
+  [& body]
+  (when #?(:clj (not (:ns &env)) :cljs (re-matches #".*\$macros" (name (ns-name *ns*))))
+    `(do ~@body)))
+
+(defmacro case [& {:keys [cljs clj]}]
+  (if (contains? &env '&env)
+    `(if (:ns ~'&env) ~cljs ~clj)
+    (if #?(:clj (:ns &env) :cljs true)
+      cljs
+      clj)))

--- a/test/core/mount/test_self_host.cljs
+++ b/test/core/mount/test_self_host.cljs
@@ -1,0 +1,17 @@
+(ns mount.test-self-host
+  (:require
+    [cljs.test :as t]
+
+    mount.test.fun-with-values
+    mount.test.private-fun
+    mount.test.printing
+    ))
+
+(t/run-tests
+ 'mount.test.fun-with-values
+ 'mount.test.private-fun
+ 'mount.test.printing
+ )
+
+(defn run-tests []
+  (t/run-all-tests #"mount.test.*"))


### PR DESCRIPTION
This patch makes mount self-host compatible so that it can be used in
environments like lumo, planck, etc.

It is a duplicate, and most of the work has been done by @dm3 in #85.

The patch also adds a `package.json` file, which can be used for deploying to npmjs, which is the JS/node equivalent of Maven Central.
 
Lumo can currently read sources for `npm`, see [here](https://github.com/anmonteiro/lumo/issues/130#issuecomment-330083804).

Finally, I have added minimal testing and [`lein-tach`](https://github.com/mfikes/tach) plugin to `project.clj`, it can be tested with:

```
npm install -g lumo-cljs
lein tach lumo
```

