### PR TITLE
Silent *logger* warning in latest ClojureScript

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mount "0.1.12-SNAPSHOT"
+(defproject mount "0.1.15-SNAPSHOT"
   :description "managing Clojure and ClojureScript app state since (reset)"
   :url "https://github.com/tolitius/mount"
   :license {:name "Eclipse Public License"

--- a/src/mount/tools/logger.cljc
+++ b/src/mount/tools/logger.cljc
@@ -3,7 +3,7 @@
              (:import [goog.debug Console])]))
 
 #?(:cljs
-    (defonce *logger*
+    (defonce ^:dynamic *logger*
       (do
         (.setCapturing (Console.) true)
         (glog/getLogger "mount"))))


### PR DESCRIPTION
The latest version is a bit stricter and emits a warning for ear-muffed vars
with no ^:dynamic.