### PR TITLE
prevent reloading of mount.core ns - fix https://github.com/tolitius/mount/issues/106

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mount "0.1.15"
+(defproject mount "0.1.16-SNAPSHOT"
   :description "managing Clojure and ClojureScript app state since (reset)"
   :url "https://github.com/tolitius/mount"
   :license {:name "Eclipse Public License"

--- a/src/mount/core.cljc
+++ b/src/mount/core.cljc
@@ -1,4 +1,5 @@
 (ns mount.core
+  #?(:clj {:clojure.tools.namespace.repl/load false}) ; prevent reloading of this ns
   #?(:clj (:require [mount.tools.macro :refer [on-error throw-runtime] :as macro]
                     [mount.tools.macrovich :refer [deftime]]
                     [mount.tools.logger :refer [log]]
@@ -16,10 +17,6 @@
 (defonce ^:private mode (atom :clj))
 (defonce ^:private meta-state (atom {}))
 (defonce ^:private running (atom {}))                      ;; to clean dirty states on redefs
-
-;; supporting tools.namespace: (disable-reload!)
-#?(:clj
-    (alter-meta! *ns* assoc ::load false)) ;; to exclude the dependency
 
 (defn- make-state-seq [state]
   (or (:order (@meta-state state))


### PR DESCRIPTION
Instead of using `alter-meta!` I put the reload-preventing metadata into the ns form. If you prefer the `alter-meta!` way I can change it. This way feels more in the spirit of immutability ([mount-lite also does it](https://github.com/aroemers/mount-lite/blob/2.x/src/mount/lite.clj), they prevent `unload` too but it is redundant).

Also bumped project.clj version to match build.boot.