### PR TITLE
Update `only` and `except` single-arity parameter names.

### DIFF
--- a/src/mount/core.cljc
+++ b/src/mount/core.cljc
@@ -308,8 +308,8 @@
       set))
 
 (defn only
-  ([states]
-   (only (find-all-states) states))
+  ([these]
+   (only (find-all-states) these))
   ([states these]
    (intersection (mapset var-to-str these)
                  (mapset var-to-str states))))
@@ -322,8 +322,8 @@
     states))
 
 (defn except
-  ([states]
-   (except (find-all-states) states))
+  ([these]
+   (except (find-all-states) these))
   ([states these]
    (remove (mapset var-to-str these)
            (mapset var-to-str states))))


### PR DESCRIPTION
The single-arity parameter names for the `only` and `except` functions
did not match the same parameters in the dual-arity versions of the
same functions. This makes both arities use the same name for the same
parameter.