### PR TITLE
Deref mount state var in :stop function in readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In case this state needs to be cleaned / destroyed between reloads, there is als
 
 ```clojure
 (defstate conn :start (create-conn)
-               :stop (disconnect conn))
+               :stop (disconnect @conn))
 ```
 
 That is pretty much it. But wait, there is more.. this state is _a top level being_, which means it can be simply


### PR DESCRIPTION
This could be either a question or a documentation fix. In my nodejs/cljs usage of mount I found that I need to deref the var that I define with `defstate` in the `:stop` function. Is this correct and the documentation should be updated?

Could also a difference between Clojure and ClojureScript maybe?