### PR TITLE
Update defstate clj-kondo hook to return a var

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/mount/mount/"]}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ doo-index.html
 /.nrepl-history
 .cljs_rhino_repl/
 out/
+.clj-kondo/.cache

--- a/resources/clj-kondo.exports/mount/mount/config.edn
+++ b/resources/clj-kondo.exports/mount/mount/config.edn
@@ -1,3 +1,3 @@
-{:lint-as {mount.core/defstate clojure.core/def-catch-all}
- :linters {:mount/defstate {:level :warning}}
- :hooks {:analyze-call {mount.core/defstate hooks.defstate/defstate}}}
+{:linters {:mount/defstate {:level :warning}}
+ :hooks {:analyze-call {mount.core/defstate hooks.defstate/defstate
+                        mount.core/defstate! hooks.defstate/defstate}}}

--- a/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
+++ b/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
@@ -32,8 +32,10 @@
          :col     (:col (meta n))})
       :else
       {:node (api/list-node
-                  (list*
-                    (api/token-node 'fn*)
-                    (api/vector-node [n])
+                  (list
+                    (api/token-node 'def)
                     n
-                    args))})))
+                    (api/list-node
+                      (list*
+                        (api/token-node 'do)
+                        args))))})))

--- a/test/clj/tapp/utils/datomic.clj
+++ b/test/clj/tapp/utils/datomic.clj
@@ -6,8 +6,9 @@
 (defn entity [conn id]
   (d/entity (d/db conn) id))
 
-(defn touch [conn results]
+(defn touch
   "takes 'entity ids' results from a query
     e.g. '#{[272678883689461] [272678883689462] [272678883689459] [272678883689457]}'"
+  [conn results]
   (let [e (partial entity conn)]
     (map #(-> % first e d/touch) results)))


### PR DESCRIPTION
Follow-up to #130, addresses the issue mentioned in https://github.com/tolitius/mount/pull/130#issuecomment-1980554084.

### Problem statement

The clj-kondo hook for `defstate` doesn't register the state's symbol as a var, which marks all subsequent usages as unresolved symbols. This is because for `(defstate conf :start (load-config))`, it produces the node `(fn* [conf] conf :start (load-config))`.

### Proposed solution

Change the produced node to `(def conf (do :start (load-config)))`.

I also added a `.clj-kondo/config.edn` which references the config in `resources/`, to make it easier to use in this project. And I moved the hook folder into the `mount/mount` folder, which helps clj-kondo find it easier and prevents merge-conflicts if a user calls `--copy-configs` and multiple projects have defined `resources/clj-kondo.exports/hooks` folders.