### PR TITLE
Fix clj-kondo config, part 3: Remove wrapping atom from clj-kondo hook

### DIFF
--- a/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
+++ b/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
@@ -34,8 +34,6 @@
               (cond-> [(api/token-node 'def) n]
                 docs (conj docs)
                 true (conj (api/list-node
-                            [(api/token-node 'atom)
-                             (api/list-node
-                              (list*
-                               (api/token-node 'do)
-                               args))]))))})))
+                            (list*
+                             (api/token-node 'do)
+                             args)))))})))


### PR DESCRIPTION
This will not work if you use the [Disable lazy start](https://github.com/tolitius/mount?tab=readme-ov-file#disable-lazy-start) mode, but you can `^:clj-kondo/ignore` those.

Fixes the issue mentioned in #137.