### PR TITLE
fix parameters of goog.log functions to prevent compiler warnings

### DIFF
--- a/src/mount/tools/logger.cljc
+++ b/src/mount/tools/logger.cljc
@@ -6,7 +6,7 @@
     (defonce ^:dynamic *logger*
       (do
         (.setCapturing (Console.) true)
-        (glog/getLogger "mount"))))
+        (glog/getLogger "mount" nil))))
 
 #?(:clj
     (defn log [msg & _]
@@ -15,6 +15,6 @@
 #?(:cljs
     (defn log [msg & level]
       (case (first level)
-        :error (glog/error *logger* msg)
-        (glog/info *logger* msg))))
+        :error (glog/error *logger* msg nil)
+        (glog/info *logger* msg nil))))
 


### PR DESCRIPTION
This is about issue #121 — warnings emitted during compilation.

I still think mount should not include any logging functionality, but fixing these warnings is the next best thing.
