### PR TITLE
fix(clj-kondo): infer defstate type from :start, not :stop (#141)

### DIFF
--- a/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
+++ b/resources/clj-kondo.exports/mount/mount/hooks/defstate.clj
@@ -30,10 +30,20 @@
          :row     (:row (meta n))
          :col     (:col (meta n))})
       :else
-      {:node (api/list-node
-              (cond-> [(api/token-node 'def) n]
-                docs (conj docs)
-                true (conj (api/list-node
-                            (list*
-                             (api/token-node 'do)
-                             args)))))})))
+      ;; A state's value is the result of `:start`, never `:stop`. clj-kondo
+      ;; infers the var's type from the LAST expression of the generated `do`,
+      ;; so emitting the `:stop` body last made it adopt the stop fn's return
+      ;; type (typically `nil`) -- producing false `Expected: <X>, received: nil`
+      ;; at deref / typed call sites (see #141). Order the lifecycle pairs so the
+      ;; `:start` body is evaluated last; the `:stop` body is still analysed.
+      (let [start? (fn [pair] (= :start (api/sexpr (first pair))))
+            pairs  (partition 2 args)
+            args   (mapcat identity (concat (remove start? pairs)
+                                            (filter start? pairs)))]
+        {:node (api/list-node
+                (cond-> [(api/token-node 'def) n]
+                  docs (conj docs)
+                  true (conj (api/list-node
+                              (list*
+                               (api/token-node 'do)
+                               args)))))}))))


### PR DESCRIPTION
## Problem

The bundled clj-kondo hook for `defstate` expands

```clj
(defstate state :start (start!) :stop (stop! @state))
```

to

```clj
(def state (do :start (start!) :stop (stop! @state)))
```

clj-kondo infers a var's type from the **last** expression of a `do`. Here that's the `:stop` body, so the state var adopts the stop fn's return type. When `:stop` returns `nil` (the usual teardown shape), clj-kondo decides the state itself is `nil`, and every typed use of the state becomes a false positive:

```
src/repro.clj: error: Expected: deref, received: nil.   ;; on (:bus @state)
```

That is #141. The same mechanism fires against any typed consumer, not just deref. A Malli-annotated fn (`malli.experimental/defn`, whose `:- schema` annotations clj-kondo type-checks) that takes a state as a `[:map]` argument reports `Expected: map, received: nil`.

## Fix

A mount state's value is always the result of `:start`, never `:stop`. Reorder the lifecycle pairs so the `:start` body is evaluated **last** in the generated `do`; the `:stop` body is still emitted, so unused-binding / unresolved-symbol analysis is unchanged. The var then gets the type of its `:start` expression.

```clj
(def state (do :stop (stop! @state) :start (start!)))
```

The change is confined to the `:else` branch; the lifecycle-key, `:on-reload`, and arity validations are untouched.

## Why not type the state as an atom (the suggestion in #141)

Wrapping the body in `(atom ...)` fixes `@state` but mistypes **every** state as an atom. Most states are not atoms (config maps, connection pools, clients), so it would break the common direct-use case, e.g. passing a config-map state to a fn that expects a map. Inferring the var's type from `:start` is correct for both `@state` and direct use.

## Verified

- #141's `@state` repro: false positive gone.
- A state passed to a Malli-typed `[:map]` param: `Expected: map, received: nil` gone.
- Lifecycle-key validation still fires (`:restart` -> "lifecycle functions can only contain `:start` and `:stop`").
- A state with no `:stop`, and direct typed uses, unaffected (expansion is identical when `:start` is already last).

Fixes #141
